### PR TITLE
Refine mobile slot action icon placement

### DIFF
--- a/assets_css/farm-slots.css
+++ b/assets_css/farm-slots.css
@@ -95,6 +95,26 @@
 .farm-slot .slot-action .feed-icon { font-size: 32px; }
 .farm-slot .slot-action .harvest-icon { font-size: 32px; }
 
+@media (max-width: 768px) {
+    .farm-slot .slot-action img {
+        width: 20px;
+        height: 20px;
+        margin: 1px;
+    }
+
+    .farm-slot .slot-action .action-icon {
+        width: 20px;
+        height: 20px;
+        margin: 1px;
+    }
+
+    .farm-slot .slot-action .water-icon,
+    .farm-slot .slot-action .feed-icon,
+    .farm-slot .slot-action .harvest-icon {
+        font-size: 20px;
+    }
+}
+
 .farm-slot .slot-action.harvest {
     cursor: default;
 }


### PR DESCRIPTION
## Summary
- Keep action overlay anchored to the top-left on mobile
- Display 20px action icons and emoji markers on small screens

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b0403e499883238727490804ddae5f